### PR TITLE
add handshake charts

### DIFF
--- a/prometheus/protocols.json
+++ b/prometheus/protocols.json
@@ -30,7 +30,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 10,
-  "iteration": 1631639543210,
+  "iteration": 1631774993816,
   "links": [],
   "panels": [
     {
@@ -41,6 +41,205 @@
         "w": 24,
         "x": 0,
         "y": 0
+      },
+      "id": 50,
+      "panels": [],
+      "title": "Handshake",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 44,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "1-(bee_handshake_ack_rx{namespace=~\"$namespace\", instance=~\"$instance\"}-bee_handshake_ack_rx_failed{namespace=~\"$namespace\", instance=~\"$instance\"})/bee_handshake_ack_rx{namespace=~\"$namespace\", instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "ACK RX Fail Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 46,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "1-(bee_handshake_syn_ack_tx{namespace=~\"$namespace\", instance=~\"$instance\"}-bee_handshake_syn_ack_tx_failed{namespace=~\"$namespace\", instance=~\"$instance\"})/bee_handshake_syn_ack_tx{namespace=~\"$namespace\", instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SYN-ACK TX Fail Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 48,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "1-(bee_handshake_syn_rx{namespace=~\"$namespace\", instance=~\"$instance\"}-bee_handshake_syn_rx_failed{namespace=~\"$namespace\", instance=~\"$instance\"})/bee_handshake_syn_rx{namespace=~\"$namespace\", instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "SYN RX Fail Rate",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
       },
       "id": 34,
       "panels": [],
@@ -62,10 +261,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -77,7 +272,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 1
+        "y": 10
       },
       "id": 38,
       "options": {
@@ -86,9 +281,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": [],
           "fields": "",
           "values": false
         },
@@ -99,9 +292,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "increase(bee_chainsyncer_synced_peers_count{namespace=~\"$namespace\", instance=~\"$instance\"}[1m])",
+          "expr": "bee_chainsyncer_synced_peers_count{namespace=~\"$namespace\", instance=~\"$instance\"}",
           "interval": "",
-          "legendFormat": "synced_peers_count({{instance}})",
+          "legendFormat": "{{instance}}",
           "refId": "A"
         }
       ],
@@ -135,7 +328,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 1
+        "y": 10
       },
       "id": 42,
       "options": {
@@ -157,9 +350,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "increase(bee_chainsyncer_unsynced_peers_count{namespace=~\"$namespace\", instance=~\"$instance\"}[1m])",
+          "expr": "bee_chainsyncer_unsynced_peers_count{namespace=~\"$namespace\", instance=~\"$instance\"}",
           "interval": "",
-          "legendFormat": "unsynced_peers_count({{instance}})",
+          "legendFormat": "{{instance}}",
           "refId": "A"
         }
       ],
@@ -193,7 +386,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 1
+        "y": 10
       },
       "id": 32,
       "options": {
@@ -217,7 +410,7 @@
           "exemplar": true,
           "expr": "increase(bee_chainsyncer_invalid_proof_count{namespace=~\"$namespace\", instance=~\"$instance\"}[1m])",
           "interval": "",
-          "legendFormat": "invalid_proof_count({{instance}})",
+          "legendFormat": "{{instance}}",
           "refId": "A"
         }
       ],
@@ -251,7 +444,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 1
+        "y": 10
       },
       "id": 36,
       "options": {
@@ -275,7 +468,7 @@
           "exemplar": true,
           "expr": "increase(bee_chainsyncer_peer_error_count{namespace=~\"$namespace\", instance=~\"$instance\"}[1m])",
           "interval": "",
-          "legendFormat": "peer_error_count({{instance}})",
+          "legendFormat": "{{instance}}",
           "refId": "A"
         }
       ],
@@ -314,7 +507,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 9
+        "y": 18
       },
       "id": 40,
       "options": {
@@ -338,7 +531,7 @@
           "exemplar": true,
           "expr": "increase(bee_chainsyncer_total_time_waiting{namespace=~\"$namespace\", instance=~\"$instance\"}[1m])/1000000",
           "interval": "",
-          "legendFormat": "total_time_waiting({{instance}})",
+          "legendFormat": "{{instance}}",
           "refId": "A"
         }
       ],
@@ -354,7 +547,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 26
       },
       "id": 22,
       "panels": [],
@@ -379,7 +572,7 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 27
       },
       "hiddenSeries": false,
       "id": 24,
@@ -493,7 +686,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 27
       },
       "hiddenSeries": false,
       "id": 25,
@@ -583,7 +776,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 38
       },
       "id": 12,
       "panels": [],
@@ -608,7 +801,7 @@
         "h": 13,
         "w": 9,
         "x": 0,
-        "y": 30
+        "y": 39
       },
       "hiddenSeries": false,
       "id": 8,
@@ -719,7 +912,7 @@
         "h": 13,
         "w": 9,
         "x": 9,
-        "y": 30
+        "y": 39
       },
       "hiddenSeries": false,
       "id": 26,
@@ -838,7 +1031,7 @@
         "h": 13,
         "w": 6,
         "x": 18,
-        "y": 30
+        "y": 39
       },
       "id": 27,
       "options": {
@@ -878,7 +1071,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 52
       },
       "id": 14,
       "panels": [],
@@ -903,7 +1096,7 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 44
+        "y": 53
       },
       "hiddenSeries": false,
       "id": 15,
@@ -1027,7 +1220,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 44
+        "y": 53
       },
       "id": 28,
       "options": {
@@ -1083,7 +1276,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 55
+        "y": 64
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1151,7 +1344,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 55
+        "y": 64
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1220,7 +1413,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 65
+        "y": 74
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1277,8 +1470,8 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "bee-bootnode",
-          "value": "bee-bootnode"
+          "text": "staging",
+          "value": "staging"
         },
         "datasource": "Prometheus",
         "definition": "label_values(bee_info, namespace)",
@@ -1357,5 +1550,5 @@
   "timezone": "",
   "title": "Bee Protocols",
   "uid": "Pu4msSbMk",
-  "version": 3
+  "version": 7
 }


### PR DESCRIPTION
adds the handshake row with the following
metrics to the protocol dashboard:

- ACK RX Fail Rate
- SYN-ACK TX Fail Rate
- SYN RX Fail Rate

<img width="1846" alt="Screen Shot 2021-09-16 at 09 26 42" src="https://user-images.githubusercontent.com/4932785/133569146-f786977c-0da8-4cd8-bdf2-0c2161d97e9f.png">
